### PR TITLE
Replace THL A29 Limited with Tencent

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Tencent is pleased to support the open source community by making Setup Tencent Kona available.
 
-Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved. The below software in this distribution may have been modified by THL A29 Limited ("Tencent Modifications"). All Tencent Modifications are Copyright (C) THL A29 Limited.
+Copyright (C) 2025 Tencent. All rights reserved. The below software in this distribution may have been modified by Tencent ("Tencent Modifications"). All Tencent Modifications are Copyright (C) Tencent.
 
 Setup Tencent Kona is licensed under the MIT License except for the third-party components listed below.
 
@@ -19,7 +19,7 @@ Other dependencies and licenses:
 
 
 Open Source Software Licensed under the MIT License:
-The below software in this distribution may have been modified by THL A29 Limited ("Tencent Modifications"). All Tencent Modifications are Copyright (C) 2025 THL A29 Limited.
+The below software in this distribution may have been modified by Tencent ("Tencent Modifications"). All Tencent Modifications are Copyright (C) 2025 Tencent.
 --------------------------------------------------------------------
 1. setup-java
 Copyright (c) 2018 GitHub, Inc. and contributors


### PR DESCRIPTION
According to the [notice], it has to replace `THL A29 Limited` with `Tencent` in the copyright notes.

This PR will resolve #22.

[notice]:
https://github.com/Tencent/.github/blob/main/profile/README.md